### PR TITLE
Separate scan endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,13 @@ openssl ciphers -V 'ALL:COMPLEMENTOFALL'
 ```
 
 Example requests:
+Collect certificate information:
 ```
-curl "http://localhost:8080/api/v1/scan?host=intranetlib.geneseo.edu:443"
+curl "http://localhost:8080/api/v1/scan/certificate?host=www.google.com:443"
 ```
+Collect server configuration:
 ```
-curl "http://localhost:8080/api/v1/scan?host=www.google.com"
-```
-Or a real bad server:
-```
-curl "http://localhost:8080/api/v1/scan?host=kis.mhs.ch"
+curl "http://localhost:8080/api/v1/scan/configuration?host=www.google.com"
 ```
 ```
 curl -X POST --data-binary @test.csr "http://localhost:8080/api/v1/parser/csr"
@@ -64,7 +62,7 @@ Build container:
 make build
 ```
 
-Run containers:
+Run integration containers (for manual testing):
 ```
 make run
 ```

--- a/controllers/scanner.go
+++ b/controllers/scanner.go
@@ -14,12 +14,13 @@ import (
 // ScanRoutes builds and returns routes for scanning
 func ScanRoutes() *chi.Mux {
 	r := chi.NewRouter()
-	r.Get("/", scanHandler)
+	r.Get("/certificate", scanCertHandler)
+	r.Get("/configuration", scanConfigHandler)
 	return r
 }
 
-func scanHandler(w http.ResponseWriter, r *http.Request) {
-	var results scanner.Results
+func scanCertHandler(w http.ResponseWriter, r *http.Request) {
+	var results scanner.CertificateData
 
 	scanHost := r.URL.Query().Get("host")
 	scanPort := "443"
@@ -48,7 +49,44 @@ func scanHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results.Scan(scanHost, scanPort)
+	results.ScanCertificate(scanHost, scanPort)
+
+	render.Status(r, http.StatusOK)
+	render.JSON(w, r, results)
+
+}
+
+func scanConfigHandler(w http.ResponseWriter, r *http.Request) {
+	var results scanner.ConfigurationData
+
+	scanHost := r.URL.Query().Get("host")
+	scanPort := "443"
+
+	if strings.Contains(scanHost, ":") {
+		l := strings.Split(scanHost, ":")
+		scanHost = l[0]
+		scanPort = l[1]
+	}
+
+	if !utils.ValidHost(scanHost) || !utils.ValidPort(scanPort) {
+		logger.Warnf("event_id=invalid_hostname host=%s", scanHost)
+		render.Status(r, http.StatusBadRequest)
+
+		m := map[string]string{"400": "invalid host or port"}
+		render.JSON(w, r, m)
+		return
+	}
+
+	if !utils.CanConnect(scanHost, scanPort) {
+		logger.Warnf("event_id=host_unreachable hostname=%s:%s", scanHost, scanPort)
+		render.Status(r, http.StatusBadRequest)
+
+		m := map[string]string{"400": "host unreachable"}
+		render.JSON(w, r, m)
+		return
+	}
+
+	results.ScanConfiguration(scanHost, scanPort)
 
 	render.Status(r, http.StatusOK)
 	render.JSON(w, r, results)

--- a/test_setup/integration_tests.py
+++ b/test_setup/integration_tests.py
@@ -10,7 +10,8 @@ import urllib.request
 import urllib.parse
 
 APP_HOST = "http://localhost:8080/api/v1"
-SCAN_URL = APP_HOST + "/scan"
+SCAN_CERT_URL = APP_HOST + "/scan/certificate"
+SCAN_CONFIG_URL = APP_HOST + "/scan/configuration"
 CSR_URL = APP_HOST + "/parse/csr"
 CERT_URL = APP_HOST + "/parse/certificate"
 
@@ -135,21 +136,24 @@ def success():
 
 def scan_test(host, data):
     params = urllib.parse.urlencode({'host':host})
-    url = SCAN_URL + '?' + params
+    cert_url = SCAN_CERT_URL + '?' + params
+    config_url = SCAN_CONFIG_URL + '?' + params
     res = {}
 
     try:
-        req = urllib.request.urlopen(url)
-        res = json.loads(req.read())
+        cert_req = urllib.request.urlopen(cert_url)
+        cert_res = json.loads(cert_req.read())
+        config_req = urllib.request.urlopen(config_url)
+        config_res = json.loads(config_req.read())
     except Exception as e:
         print("failed to connect to {}".format(host), e)
         global ERRORS
         ERRORS =+ len(data)
         return
 
-    cert = res['certificates'][0]
-    conn = res['connectionInformation']
-    vuln = res['vulnerabilities']
+    cert = cert_res['certificates'][0]
+    conn = config_res
+    vuln = conn['vulnerabilities']
 
     key_type = cert['keyType']
     server = conn['serverHeader']


### PR DESCRIPTION
This branch separates the `scan` endpoint into two.  One for collecting certificate data from the server and the second for collecting the server configuration/vulnerabilities data.  This was done to allow different uses of the api.  The idea being that a UI can retrieve data from one of both endpoints to display.