### PR TITLE
30 integration test failing due to key error

### DIFF
--- a/pkg/certutil/certificate.go
+++ b/pkg/certutil/certificate.go
@@ -29,9 +29,14 @@ type CertData struct {
 
 // CertExtensions in certificate
 type CertExtensions struct {
-	AuthorityInformationAccess map[string]string `json:"authorityInformationAccess"`
-	CRLDistributionPoints      []string          `json:"crlDistributionPoints"`
-	SubjectAlternativeNames    []string          `json:"subjectAlternativeNames"`
+	AuthorityInformationAccess AuthorityInformationAccess `json:"authorityInformationAccess"`
+	CRLDistributionPoints      []string                   `json:"crlDistributionPoints"`
+	SubjectAlternativeNames    []string                   `json:"subjectAlternativeNames"`
+}
+
+type AuthorityInformationAccess struct {
+	OCSPURL   string `json:"ocspUrl"`
+	IssuerURL string `json:"issuerUrl"`
 }
 
 // Issuer information
@@ -80,10 +85,8 @@ func IsTrusted(certs []*x509.Certificate, host string) bool {
 // ParseCert used to parse/massage certain data
 func (c *CertData) Process(cert *x509.Certificate) {
 	// extensions
-	var a = make(map[string]string)
-	a["CAIssuers"] = utils.Ltos(cert.IssuingCertificateURL)
-	a["OCSP"] = utils.Ltos(cert.OCSPServer)
-	c.Extensions.AuthorityInformationAccess = a
+	c.Extensions.AuthorityInformationAccess.IssuerURL = utils.Ltos(cert.IssuingCertificateURL)
+	c.Extensions.AuthorityInformationAccess.OCSPURL = utils.Ltos(cert.OCSPServer)
 	c.Extensions.CRLDistributionPoints = cert.CRLDistributionPoints
 	c.Extensions.SubjectAlternativeNames = cert.DNSNames
 

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -47,10 +47,10 @@ func getCertData(cList []*x509.Certificate, ocspStaple []byte) []certutil.CertDa
 
 // CertificateData information about tls connection
 type CertificateData struct {
-	Certificates    []certutil.CertData `yaml:"certificates"`
-	ChainTrusted    bool                `yaml:"chainTrusted"`
-	HostName        string              `yaml:"hostName"`
-	HostNameMatches bool                `yaml:"hostNameMatches"`
+	Certificates    []certutil.CertData `json:"certificates"`
+	ChainTrusted    bool                `json:"chainTrusted"`
+	HostName        string              `json:"hostName"`
+	HostNameMatches bool                `json:"hostNameMatches"`
 }
 
 // ScanCertificate is performs tls certificate and conn checks
@@ -75,20 +75,20 @@ func (c *CertificateData) ScanCertificate(host string, port string) {
 
 // ConfigurationData information about tls connection
 type ConfigurationData struct {
-	// ChainTrusted    bool                `yaml:"chainTrusted"`
-	// HostName        string              `yaml:"hostName"`
-	// HostNameMatches bool                `yaml:"hostNameMatches"`
-	OCSPStapling    bool                `yaml:"ocspStapling"`
-	ServerHeader    string              `yaml:"serverHeader"`
-	SupportedConfig map[string][]string `yaml:"supportedConfig"`
-	Vulnerabilities Vulnerabilities     `yaml:"vulnerabilities"`
+	// ChainTrusted    bool                `json:"chainTrusted"`
+	// HostName        string              `json:"hostName"`
+	// HostNameMatches bool                `json:"hostNameMatches"`
+	OCSPStapling    bool                `json:"ocspStapling"`
+	ServerHeader    string              `json:"serverHeader"`
+	SupportedConfig map[string][]string `json:"supportedConfig"`
+	Vulnerabilities Vulnerabilities     `json:"vulnerabilities"`
 }
 
 // Vulnerabilities struct of vuln results
 type Vulnerabilities struct {
-	DebianWeakKey weakkey.DebianWeakKey `yaml:"debianWeakKey"`
-	Heartbleed    heartbleed.Heartbleed `yaml:"heartbleed"`
-	CCSInjection  ccs.CCSInjection      `yaml:"ccsinjection"`
+	DebianWeakKey weakkey.DebianWeakKey `json:"debianWeakKey"`
+	Heartbleed    heartbleed.Heartbleed `json:"heartbleed"`
+	CCSInjection  ccs.CCSInjection      `json:"ccsinjection"`
 }
 
 // ScanConfiguration is performs tls certificate and conn checks


### PR DESCRIPTION
The CertificateData, ConfigurationData, and Vulnerabilities structs had field tags set incorrectly to yaml instead of json.