### PR TITLE
reconfigure dependabot to group updates and run monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,24 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to reduce the frequency of dependency update checks and to group updates together for easier management.

**Dependabot configuration changes:**

* Changed the update schedule for `gomod`, `github-actions`, and `docker` dependencies from weekly to monthly to reduce noise from frequent pull requests.
* Added grouping for each ecosystem so that all updates are bundled together in a single pull request, making dependency management more efficient.